### PR TITLE
Tornar init.py não intrusivo e adicionar YODA Prep Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ python yoda/scripts/init.py --dev <slug> --root .
 ```
 
 ## First run / Init
-`init` appends the YODA entry block to agent files and creates the YODA folder structure if needed. It is idempotent and safe to rerun.
+`init` creates/reconciles YODA-managed structure under `yoda/` and does not create or edit host-project agent files such as `AGENTS.md`, `GEMINI.md`, `CLAUDE.md`, `REPO_INTENT.md`, or `repo.intent.yaml`. Host projects may point their own agent files to `yoda/yoda.md` manually.
 
 ## What's inside
 - `yoda/yoda.md` (embedded manual)
+- `yoda/AGENTS.md`, `yoda/GEMINI.md`, `yoda/CLAUDE.md` (YODA-local agent entries)
 - `yoda/scripts/` (CLI tools)
 - `yoda/templates/` (issue templates)
 - `yoda/PACKAGE_MANIFEST.yaml` (build metadata)

--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ Check `yoda/PACKAGE_MANIFEST.yaml` for version/build metadata and `CHANGELOG.yam
 Upgrades replace only the framework files under `yoda/` and preserve project data. Keep a backup at `yoda/_previous/<version>` to rollback by restoring the prior subtree.
 
 ## Source of truth
-The authoritative specification lives in the upstream repo: https://github.com/alexdundes/yoda (see `project/specs/`).
+For embedded projects, the operational source of truth is inside the package:
+issue Markdown under `yoda/project/issues/`, the embedded manual at
+`yoda/yoda.md`, and the runbooks printed by `yoda/scripts/*.py --help`.
 
 ## Where to read more
 - `yoda/yoda.md` for the embedded manual

--- a/package.py
+++ b/package.py
@@ -62,7 +62,6 @@ INCLUDE_GLOBS = [
 ]
 EXCLUDE_GLOBS = [
     "project/**",
-    "project/specs/**",
     "bootstrap-legacy/**",
     "yoda/logs/**",
     "yoda/todos/**",
@@ -83,8 +82,9 @@ HELP_EPILOG = """Agent runbook (read this before packaging):
 Goal:
 - Produce one release archive with traceable metadata and a matching changelog entry.
 
-1) Read the packaging contract first:
-   - project/specs/23-distribution-and-packaging.md
+1) Treat this help output as the packaging contract:
+   - package.py is the source of truth for included files, excluded files,
+     release metadata, and changelog entry creation.
 
 2) Build release notes from repository history (never guess):
    - Check working tree: git status --short

--- a/package.py
+++ b/package.py
@@ -46,6 +46,11 @@ README_REL = Path("README.md")
 LICENSE_REL = Path("LICENSE")
 YODA_LICENSE_REL = Path("yoda/LICENSE")
 YODA_MANUAL_REL = Path("yoda/yoda.md")
+YODA_AGENT_ENTRY_RELS = [
+    Path("yoda/AGENTS.md"),
+    Path("yoda/GEMINI.md"),
+    Path("yoda/CLAUDE.md"),
+]
 TEMPLATES_REL = Path("yoda/templates")
 SCRIPTS_REL = Path("yoda/scripts")
 LATEST_JSON_REL = Path("docs/install/latest.json")
@@ -55,6 +60,9 @@ INCLUDE_GLOBS = [
     "LICENSE",
     "yoda/LICENSE",
     "yoda/yoda.md",
+    "yoda/AGENTS.md",
+    "yoda/GEMINI.md",
+    "yoda/CLAUDE.md",
     "yoda/templates/**",
     "yoda/scripts/**",
     "CHANGELOG.yaml",
@@ -123,7 +131,8 @@ Goal:
 9) Final verification:
    - tar -tzf <archive> | sort
    - Required files: README.md, LICENSE, yoda/LICENSE, yoda/yoda.md,
-     CHANGELOG.yaml, yoda/PACKAGE_MANIFEST.yaml.
+     yoda/AGENTS.md, yoda/GEMINI.md, yoda/CLAUDE.md, CHANGELOG.yaml,
+     yoda/PACKAGE_MANIFEST.yaml.
 
 10) Human handoff for GitLab distribution publish:
    - Instruct the human step by step on where to upload the dist archive in GitLab.
@@ -205,7 +214,13 @@ def _digest_entry(entry: dict[str, Any]) -> str:
 
 
 def _ensure_required_paths(root: Path) -> None:
-    required_files = [README_REL, LICENSE_REL, YODA_LICENSE_REL, YODA_MANUAL_REL]
+    required_files = [
+        README_REL,
+        LICENSE_REL,
+        YODA_LICENSE_REL,
+        YODA_MANUAL_REL,
+        *YODA_AGENT_ENTRY_RELS,
+    ]
     required_dirs = [TEMPLATES_REL, SCRIPTS_REL]
     for rel in required_files:
         path = root / rel
@@ -239,7 +254,14 @@ def _is_excluded(rel_path: Path) -> bool:
 
 def _collect_files(root: Path) -> list[Path]:
     files: set[Path] = set()
-    for rel in (README_REL, LICENSE_REL, YODA_LICENSE_REL, YODA_MANUAL_REL, CHANGELOG_REL):
+    for rel in (
+        README_REL,
+        LICENSE_REL,
+        YODA_LICENSE_REL,
+        YODA_MANUAL_REL,
+        *YODA_AGENT_ENTRY_RELS,
+        CHANGELOG_REL,
+    ):
         files.add(rel)
 
     for rel_dir in (TEMPLATES_REL, SCRIPTS_REL):

--- a/project/specs/06-agent-playbook.md
+++ b/project/specs/06-agent-playbook.md
@@ -41,6 +41,7 @@ When human intent is to start YODA Flow:
 
 ## General rules
 
+- For embedded YODA, use the YODA-local entry files under `yoda/` and `yoda/yoda.md`; do not assume YODA controls host-root agent files.
 - Before operating any YODA command, check `<command> --help` for command-specific runbook/guidance.
 - Do not rely on removed flow contracts (`todo_next.py`).
 - Do not duplicate dependency metadata in issue body.

--- a/project/specs/07-agent-entry-files.md
+++ b/project/specs/07-agent-entry-files.md
@@ -1,4 +1,4 @@
-# Agent entry and root file
+# Agent entry files
 
 ## Problem
 
@@ -6,14 +6,20 @@ Agent tools do not agree on which file to read (`AGENTS.md`, `GEMINI.md`, etc.).
 
 ## YODA proposal
 
-- Root file: `yoda/yoda.md`.
-- This file contains the agent instructions for the project.
-- In an embedded YODA setup, `yoda/yoda.md` is the **README.md** for the YODA layer inside a host project (human-readable context for agents).
-- init creates/updates agent entry files (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`) pointing to `yoda/yoda.md`, appending a delimited YODA block to preserve existing content.
+- YODA is non-intrusive in host projects.
+- YODA-owned agent entry files live under `yoda/`:
+  - `yoda/AGENTS.md`
+  - `yoda/GEMINI.md`
+  - `yoda/CLAUDE.md`
+- These files route agents to `yoda/yoda.md`.
+- `yoda/yoda.md` contains the operational instructions for the embedded YODA layer.
+- `init.py` MUST NOT create, update, append to, merge, or delete host-root agent or intent files such as `AGENTS.md`, `GEMINI.md`, `CLAUDE.md`, `REPO_INTENT.md`, or `repo.intent.yaml`.
 
 ## Interoperability
 
-- `AGENTS.md` (Codex), `GEMINI.md` (Gemini CLI / anti-gravity), and other supported files only route to `yoda/yoda.md`.
+- Host projects MAY keep their own root-level agent files.
+- If a host project wants agent tools to discover YODA automatically, the host may manually point its own files to `yoda/yoda.md` or the YODA-local entry files.
+- YODA package/update owns only files under `yoda/`.
 
 ## Simplified entry flow
 
@@ -21,7 +27,7 @@ Agent tools do not agree on which file to read (`AGENTS.md`, `GEMINI.md`, etc.).
 2) User types a natural phrase indicating entering YODA Flow and taking the highest-priority selectable issue (with all dependencies resolved, and no issue currently `doing`).
    - The phrase must explicitly mention "YODA Flow" (or "YODA") and intent to take the highest-priority selectable issue (with all dependencies resolved).
    - Example: "Vamos entrar no YODA Flow e pegar a issue prioritaria sem dependencias."
-3) Agent reads `yoda/yoda.md`.
+3) Agent reads the relevant YODA-local entry file (`yoda/AGENTS.md`, `yoda/GEMINI.md`, or `yoda/CLAUDE.md`) when available, then reads `yoda/yoda.md`.
 4) Agent resolves the developer slug in this order:
    - --dev `<slug>` flag
    - Ask the user when `--dev` is missing

--- a/project/specs/12-yoda-structure.md
+++ b/project/specs/12-yoda-structure.md
@@ -5,6 +5,9 @@
 ```text
 .
 ├─ yoda/
+│  ├─ AGENTS.md
+│  ├─ GEMINI.md
+│  ├─ CLAUDE.md
 │  ├─ yoda.md
 │  ├─ templates/
 │  │  └─ issue.md
@@ -20,6 +23,12 @@
 
 - Canonical flow execution data lives in `yoda/project/issues/*.md`.
 - Issue IDs are filename-derived.
+
+## Agent entry files
+
+- YODA-local agent entry files live in `yoda/AGENTS.md`, `yoda/GEMINI.md`, and `yoda/CLAUDE.md`.
+- These files point to `yoda/yoda.md` and are framework files.
+- Host-root agent files are outside YODA ownership and are not created or modified by `init.py`.
 
 ## Compatibility data
 

--- a/project/specs/23-distribution-and-packaging.md
+++ b/project/specs/23-distribution-and-packaging.md
@@ -20,6 +20,7 @@ Defines the distributable artefact of the YODA Framework and the contract expect
 
 ## Included content
 - `yoda/yoda.md` (or successors) — embedded manual for agents.
+- `yoda/AGENTS.md`, `yoda/GEMINI.md`, `yoda/CLAUDE.md` — YODA-local agent entry files.
 - `yoda/templates/` — issue templates.
 - `yoda/scripts/` — official scripts (`todo_*`, `issue_add`, `log_add`, etc.), excluding `yoda/scripts/tests/`.
 - `LICENSE` — short license file for the package.
@@ -42,6 +43,9 @@ Defines the distributable artefact of the YODA Framework and the contract expect
 <root>/LICENSE
 <root>/README.md
 <root>/yoda/LICENSE
+<root>/yoda/AGENTS.md
+<root>/yoda/GEMINI.md
+<root>/yoda/CLAUDE.md
 <root>/yoda/PACKAGE_MANIFEST.yaml
 <root>/CHANGELOG.yaml
 ```
@@ -98,7 +102,8 @@ Rules:
 
 ## `init` command requirements (consumer; implemented separately)
 - Assumes the layout defined here.
-- Creates the host project skeleton (AGENTS.md, `yoda/todos/TODO.<dev>.yaml`, etc.) without relying on `project/specs/`.
+- Creates/reconciles only YODA-owned structure under `yoda/` without relying on `project/specs/`.
+- MUST NOT create or mutate host-root agent or intent files (`AGENTS.md`, `GEMINI.md`, `CLAUDE.md`, `REPO_INTENT.md`, `repo.intent.yaml`).
 - MUST validate package version/build and warn on incompatibilities (MAJOR or older build).
 
 ## Compatibility and upgrade

--- a/project/specs/24-installation-and-upgrade.md
+++ b/project/specs/24-installation-and-upgrade.md
@@ -22,6 +22,10 @@ Upgrade/install processes MUST preserve:
 2) Keep backup before replacement.
 3) Run updated `init.py` to finalize sync and migration checks.
 
+`init.py` finalization is non-intrusive: it must operate only on YODA-managed
+files under `yoda/` and must not create or modify host-root agent or intent
+files.
+
 ## check/apply rule (0.3.0)
 
 - `--check` and `--apply` are defined on updated `init.py` after update.

--- a/yoda/AGENTS.md
+++ b/yoda/AGENTS.md
@@ -1,0 +1,5 @@
+# YODA Agent Entry
+
+Read `yoda/yoda.md` before operating this embedded YODA framework.
+
+Use script `--help` output as the source of truth for operational runbooks.

--- a/yoda/CLAUDE.md
+++ b/yoda/CLAUDE.md
@@ -1,0 +1,5 @@
+# YODA Claude Entry
+
+Read `yoda/yoda.md` before operating this embedded YODA framework.
+
+Use script `--help` output as the source of truth for operational runbooks.

--- a/yoda/GEMINI.md
+++ b/yoda/GEMINI.md
@@ -1,0 +1,5 @@
+# YODA Gemini Entry
+
+Read `yoda/yoda.md` before operating this embedded YODA framework.
+
+Use script `--help` output as the source of truth for operational runbooks.

--- a/yoda/project/extern_issues/github-006.json
+++ b/yoda/project/extern_issues/github-006.json
@@ -1,0 +1,30 @@
+{
+  "provider": "github",
+  "number": "6",
+  "title": "Flow antecipado.",
+  "description": "Criar um fluxo alternativo ao YODA Flow, que apenas trate a documenta\u00e7\u00e3o da issue, sem implementar nada.\nCaso esse fluxo alternativo seja executado, quando entrar no YODA Flow, essa issue pular\u00e1 a fase de Sutdy e Document pulando direto para Implement.",
+  "state": "open",
+  "author": "alexdundes",
+  "url": "https://github.com/alexdundes/yoda/issues/6",
+  "labels": [],
+  "log": [
+    {
+      "type": "timeline:added_to_project_v2",
+      "id": "26202106153",
+      "author": "github-project-automation[bot]",
+      "created_at": "2026-06-01T18:43:24Z",
+      "updated_at": "",
+      "body": "event: added_to_project_v2; commit: None",
+      "url": ""
+    },
+    {
+      "type": "timeline:project_v2_item_status_changed",
+      "id": "26202107529",
+      "author": "github-project-automation[bot]",
+      "created_at": "2026-06-01T18:43:25Z",
+      "updated_at": "",
+      "body": "event: project_v2_item_status_changed; commit: None",
+      "url": ""
+    }
+  ]
+}

--- a/yoda/project/extern_issues/github-006.json
+++ b/yoda/project/extern_issues/github-006.json
@@ -25,6 +25,15 @@
       "updated_at": "",
       "body": "event: project_v2_item_status_changed; commit: None",
       "url": ""
+    },
+    {
+      "type": "timeline:referenced",
+      "id": "26208155954",
+      "author": "alexdundes",
+      "created_at": "2026-06-01T21:31:42Z",
+      "updated_at": "",
+      "body": "event: referenced; commit: 8a2f14b5669211f78eea5a381dafbb5a6ce910fb",
+      "url": ""
     }
   ]
 }

--- a/yoda/project/extern_issues/github-007.json
+++ b/yoda/project/extern_issues/github-007.json
@@ -1,0 +1,30 @@
+{
+  "provider": "github",
+  "number": "7",
+  "title": "init.py n\u00e3o atua sobre arquivos de agente do projeto",
+  "description": "Atualmente o init.py est\u00e1 atualizando arquivos markdown voltados para agentes na pasta do projeto em que o YODA est\u00e1 embarcado.\n\nDevemos alterar para o init.py n\u00e3o fazer mais essas altera\u00e7\u00f5es.\n\nE vamos tamb\u00e9m alterar para os arquivos voltados para os agentes ficarem todos dentro da pasta yoda/ ,\nO YODA \u00e9 auto contido, esses arquivos ir\u00e3o na atualiza\u00e7\u00e3o (update, package) e ser\u00e3o sempre substituidos.\n\n\u00c9 uma mudan\u00e7a de abordagem.\n\nO YODA passa a ser algo n\u00e3o intrusivo com as instru\u00e7\u00f5es do projeto. ",
+  "state": "open",
+  "author": "alexdundes",
+  "url": "https://github.com/alexdundes/yoda/issues/7",
+  "labels": [],
+  "log": [
+    {
+      "type": "timeline:added_to_project_v2",
+      "id": "26235759525",
+      "author": "github-project-automation[bot]",
+      "created_at": "2026-06-02T12:06:42Z",
+      "updated_at": "",
+      "body": "event: added_to_project_v2; commit: None",
+      "url": ""
+    },
+    {
+      "type": "timeline:project_v2_item_status_changed",
+      "id": "26235759996",
+      "author": "github-project-automation[bot]",
+      "created_at": "2026-06-02T12:06:43Z",
+      "updated_at": "",
+      "body": "event: project_v2_item_status_changed; commit: None",
+      "url": ""
+    }
+  ]
+}

--- a/yoda/project/issues/yoda-0062-adicionar-fluxo-antecipado-de-study-e-document.md
+++ b/yoda/project/issues/yoda-0062-adicionar-fluxo-antecipado-de-study-e-document.md
@@ -1,0 +1,185 @@
+---
+schema_version: '2.00'
+status: done
+title: Adicionar fluxo antecipado de Study e Document
+description: Criar um fluxo alternativo ao YODA Flow para executar apenas o trabalho
+  de Study e Document de uma issue, sem implementar nada, deixando a issue pronta
+  para entrar posteriormente no YODA Flow diretamente em Implement.
+priority: 5
+extern_issue_file: ../extern_issues/github-006.json
+created_at: '2026-06-01T17:52:26-03:00'
+updated_at: '2026-06-01T18:30:53-03:00'
+---
+
+# yoda-0062 - Adicionar fluxo antecipado de Study e Document
+
+## Summary
+Criar o **YODA Prep Flow**, um fluxo operacional alternativo ao YODA Flow para
+antecipar apenas as fases de Study e Document de uma issue. Esse fluxo deve
+preparar uma issue especifica sem executar implementacao, manter a issue como
+`to-do` e registrar no front matter que ela deve iniciar em Implement quando for
+selecionada posteriormente pelo YODA Flow normal.
+
+## Context
+O YODA Flow atual segue a sequencia Study, Document, Implement e Evaluate. Em
+alguns casos, a documentacao de uma issue precisa ser refinada antes do momento
+de implementacao, mas entrar no Flow normal pode misturar preparacao documental
+com execucao tecnica.
+
+A issue externa GitHub #6 solicita um "Flow antecipado" que trate somente a
+documentacao da issue, sem implementar nada. Depois desse preparo, o Flow normal
+deve reconhecer que Study e Document ja foram feitos e deve iniciar em Implement.
+
+## Objective
+Definir e implementar `yoda/scripts/yoda_prep_flow.py` para executar o preparo
+documental de uma issue especifica, independente da ordem de execucao e das
+precedencias do backlog, persistindo `flow_prepared_until: document` para
+retomada posterior diretamente em Implement no YODA Flow.
+
+## Scope
+- Adicionar o script `yoda/scripts/yoda_prep_flow.py`.
+- Definir a entrada CLI principal como `--dev <slug> --issue <id>`.
+- Permitir que o YODA Prep Flow atue sobre uma issue especifica,
+  independente da ordem de selecao do backlog e das precedencias.
+- Persistir o marcador opcional `flow_prepared_until: document` no front matter.
+- Manter a issue preparada com `status: to-do`.
+- Garantir que o YODA Flow reconheca `flow_prepared_until: document` e inicie a
+  issue em `doing/implement` quando ela for selecionada.
+- Atualizar `yoda/yoda.md` para mencionar o YODA Prep Flow, explicar
+  minimamente o novo script e orientar o agente a chamar `--help` para obter o
+  runbook completo.
+- Adicionar testes para preparo, selecao normal e retomada em Implement.
+
+## Out of scope
+- Executar qualquer implementacao de produto dentro da issue preparada.
+- Alterar a ordem padrao do YODA Flow para issues nao preparadas.
+- Fazer o YODA Prep Flow obedecer precedencias do backlog para escolher issues.
+- Migrar retroativamente issues historicas.
+- Fechar ou atualizar automaticamente a issue externa no GitHub.
+
+## Requirements
+- `yoda_prep_flow.py` deve exigir `--dev` e `--issue`.
+- `--issue` deve apontar para uma issue existente do mesmo dev.
+- O script deve rejeitar issues `done`.
+- O script deve operar independentemente de dependencias, prioridade e ordem
+  seletiva do YODA Flow.
+- O script deve emitir runbooks compactos para Study e Document, sem orientar
+  Implement ou Evaluate.
+- O script deve esperar autorizacao humana entre Study e Document, seguindo a
+  mesma disciplina de uma etapa por chamada.
+- Ao concluir Document, o script deve manter `status: to-do`, remover `phase` se
+  existir, persistir `flow_prepared_until: document` e registrar linha no
+  `## Flow log`.
+- `flow_prepared_until` deve ser campo opcional; aceitar `study` como marco
+  intermediario do Prep Flow e `document` como marco final. Quando ausente, o
+  comportamento atual permanece inalterado.
+- `yoda_flow_next.py` deve interpretar `status: to-do` +
+  `flow_prepared_until: document` como entrada direta em `doing/implement`.
+- A interface deve seguir os padroes atuais dos scripts YODA: `--dev`, saida
+  markdown/json, `--dry-run` para mutacoes e help com Agent guidance.
+- `yoda/yoda.md` deve conter uma secao curta do YODA Prep Flow, sem duplicar o
+  runbook detalhado do script.
+- A orientacao em `yoda/yoda.md` deve pedir explicitamente para executar
+  `python3 yoda/scripts/yoda_prep_flow.py --help` antes de usar o fluxo.
+- A mudanca de layout/schema deve ser classificada como `subtle`.
+
+## Acceptance criteria
+- [x] Existe `yoda/scripts/yoda_prep_flow.py` com `--dev`, `--issue`,
+      `--format/json`, `--dry-run` e Agent guidance no `--help`.
+- [x] O YODA Prep Flow retorna runbook claro para Study/Document sem orientar
+      implementacao.
+- [x] O YODA Prep Flow trabalha sobre a issue indicada por `--issue`, sem
+      depender da ordem de selecao ou precedencias do backlog.
+- [x] Ao concluir Document, a issue markdown permanece `to-do` e persiste
+      `flow_prepared_until: document`.
+- [x] `yoda_flow_next.py` inicia issues preparadas diretamente em
+      `doing/implement`.
+- [x] Issues que nao passaram pelo fluxo antecipado continuam seguindo Study ->
+      Document -> Implement -> Evaluate.
+- [x] `yoda/yoda.md` menciona `yoda_prep_flow.py` e orienta consultar
+      `python3 yoda/scripts/yoda_prep_flow.py --help` para detalhes.
+- [x] Testes cobrem o caminho antecipado, o caminho normal e o comportamento de
+      `--dry-run` se houver mutacao.
+
+## Entry points
+- yoda/yoda.md
+- yoda/scripts/yoda_prep_flow.py
+- yoda/scripts/yoda_flow_next.py
+- yoda/scripts/todo_update.py
+- yoda/scripts/lib/issue_index.py
+- yoda/scripts/lib/issue_metadata.py
+- yoda/scripts/tests/test_yoda_prep_flow.py
+- yoda/scripts/tests/test_yoda_flow_next.py
+- yoda/project/extern_issues/github-006.json
+
+## Implementation notes
+Nome canonico do fluxo: **YODA Prep Flow**.
+
+Script canonico: `yoda_prep_flow.py`.
+
+Campo canonico: `flow_prepared_until`. Valores aceitos: `study` e `document`.
+
+Semantica aprovada:
+
+- `flow_prepared_until: document` significa que Study e Document ja foram
+  executados no YODA Prep Flow.
+- `flow_prepared_until: study` e usado somente como marco intermediario para
+  permitir uma etapa por chamada antes de Document.
+- A issue preparada continua `status: to-do`, porque ainda nao entrou no Flow de
+  implementacao.
+- Quando selecionada pelo YODA Flow normal, a transicao inicial deve ser
+  `to-do -> doing/implement`.
+- Campo ausente significa comportamento normal.
+- Mudanca classificada como `subtle`, por ser campo opcional compativel com
+  issues existentes.
+
+Evitar inferencias por texto livre no corpo da issue. A retomada em Implement
+deve depender exclusivamente do front matter validado.
+
+## Tests
+Adicionar ou atualizar testes em `yoda/scripts/tests/` para validar:
+
+- `yoda_prep_flow.py --help` contem Agent guidance;
+- `yoda_prep_flow.py --dev <slug> --issue <id>` inicia o preparo da issue
+  indicada, mesmo que outra issue tenha maior prioridade;
+- conclusao de Document persiste `flow_prepared_until: document` e mantem
+  `status: to-do`;
+- `yoda_flow_next.py` retoma issue preparada em `doing/implement`;
+- preservacao do fluxo normal para issues nao preparadas;
+- rejeicao de issue `done` no YODA Prep Flow;
+- ausencia de transicao para Implement/Evaluate/Done no YODA Prep Flow;
+- saida/runbook esperado para agente;
+- comportamento sem escrita com `--dry-run`.
+
+## Risks and edge cases
+- O novo campo deve entrar na ordem canonica de metadados para evitar diffs
+  instaveis.
+- Dois fluxos capazes de alterar fase/status podem divergir se nao houver uma
+  unica regra de transicao.
+- Uma issue parcialmente preparada pode ficar ambigua se o fluxo for interrompido
+  entre Study e Document.
+- O Flow normal nao deve pular Study/Document por acidente em issues antigas ou
+  em issues editadas manualmente sem marcador valido.
+- Como o Prep Flow ignora precedencias, o playbook deve deixar claro que ele nao
+  autoriza implementacao antecipada.
+- A documentacao embarcada deve permanecer resumida; detalhes de execucao devem
+  viver no `--help` do script para evitar drift entre manual e CLI.
+
+## Result log
+feat: add YODA Prep Flow
+
+Implemented `yoda_prep_flow.py` for explicit issue Study/Document preparation without implementation. Added `flow_prepared_until` metadata support, integrated prepared issues into `yoda_flow_next.py` so `to-do` issues prepared through Document start at `doing/implement`, and documented the new flow in `yoda/yoda.md` with guidance to consult the script `--help`.
+
+- **GitHub Issue** :   #006
+
+- **Issue**: `yoda-0062`
+
+- **Path**: `yoda/project/issues/yoda-0062-adicionar-fluxo-antecipado-de-study-e-document.md`
+
+## Flow log
+- 2026-06-01T17:52:26-03:00 issue_add created title=Adicionar fluxo antecipado de Study e Document; priority=5
+- 2026-06-01T18:07:49-03:00 transition to-do->doing/study
+- 2026-06-01T18:15:39-03:00 transition doing/study->doing/document | Study approved: new yoda_prep_flow.py, explicit flow_prepared_until field, subtle schema change, keep prepared issue to-do, canonical name YODA Prep Flow
+- 2026-06-01T18:22:29-03:00 transition doing/document->doing/implement | Document approved: implement YODA Prep Flow script, flow_prepared_until marker, yoda_flow_next integration, yoda.md note, and tests
+- 2026-06-01T18:29:36-03:00 transition doing/implement->doing/evaluate | Implement completed: added yoda_prep_flow.py, flow_prepared_until support, yoda_flow_next prepared issue handling, docs, and tests
+- 2026-06-01T18:30:53-03:00 transition doing/evaluate->done | Evaluate approved: acceptance criteria checked, Result log filled, full script test suite passed

--- a/yoda/project/issues/yoda-0063-tornar-init-py-n-o-intrusivo-para-arquivos-de-agente.md
+++ b/yoda/project/issues/yoda-0063-tornar-init-py-n-o-intrusivo-para-arquivos-de-agente.md
@@ -1,0 +1,182 @@
+---
+schema_version: '2.00'
+status: done
+title: "Tornar init.py n\xE3o intrusivo para arquivos de agente"
+description: "Alterar o YODA para deixar de criar ou modificar arquivos de agente\
+  \ e intent na raiz do projeto host. As instru\xE7\xF5es de agente do YODA devem\
+  \ ficar autocontidas dentro de yoda/ e ser tratadas pelo pacote/update do pr\xF3\
+  prio framework."
+priority: 5
+extern_issue_file: ../extern_issues/github-007.json
+created_at: '2026-06-02T09:09:50-03:00'
+updated_at: '2026-06-02T10:19:33-03:00'
+---
+
+# yoda-0063 - Tornar init.py não intrusivo para arquivos de agente
+
+## Summary
+Alterar a abordagem de inicializacao do YODA para que o framework nao crie nem
+modifique arquivos de agente ou intent na raiz do projeto host. As instrucoes de
+agente do YODA devem ser autocontidas dentro de `yoda/` (`yoda/AGENTS.md`,
+`yoda/GEMINI.md`, `yoda/CLAUDE.md` e `yoda/yoda.md`), seguir no pacote/update do
+proprio framework e poder ser substituidas pelo mecanismo de distribuicao do YODA.
+
+## Context
+Hoje `yoda/scripts/init.py` atua sobre arquivos markdown e YAML na raiz do
+projeto host, incluindo `AGENTS.md`, `GEMINI.md`, `CLAUDE.md`, `REPO_INTENT.md`
+e `repo.intent.yaml`. Esse comportamento foi util para onboarding, mas torna o
+YODA intrusivo nas instrucoes proprias do projeto consumidor.
+
+A issue externa GitHub #7 define uma mudanca de abordagem: o YODA deve ser
+autocontido e nao interferir nas instrucoes do projeto host. Arquivos voltados a
+agentes do YODA devem morar dentro de `yoda/`, fazer parte do artefato
+distribuivel e ser atualizados/substituidos pelo fluxo normal de update/package.
+
+## Objective
+Fazer `init.py` deixar de criar, anexar ou atualizar arquivos de agente/intent na
+raiz do projeto host e consolidar as instrucoes de agente do YODA dentro da
+pasta `yoda/`, mantendo o framework autocontido e nao intrusivo.
+
+## Scope
+- Remover de `init.py` a criacao/alteracao de `AGENTS.md`, `GEMINI.md`,
+  `CLAUDE.md`, `REPO_INTENT.md` e `repo.intent.yaml` na raiz do projeto host.
+- Criar arquivos autocontidos de entrada para agentes em `yoda/AGENTS.md`,
+  `yoda/GEMINI.md` e `yoda/CLAUDE.md`, apontando para `yoda/yoda.md`.
+- Nao criar equivalentes autocontidos de `REPO_INTENT.md` ou `repo.intent.yaml`.
+- Garantir que os arquivos autocontidos em `yoda/` entram no pacote e no fluxo de
+  update, quando aplicavel.
+- Atualizar `yoda/yoda.md` para remover a dependencia de leitura de
+  `REPO_INTENT.md` e passar a ser autocontido.
+- Atualizar README, manuais, runbooks dos scripts e documentacao operacional para
+  refletir que `init.py` nao e mais intrusivo.
+- Revisar e alinhar as especificacoes em `project/specs/` afetadas pela mudanca,
+  especialmente entrada de agentes, empacotamento e instalacao/update.
+- Atualizar testes de `init.py`, package/update e contratos CLI conforme
+  necessario.
+
+## Out of scope
+- Migrar ou remover automaticamente arquivos de agente ja existentes na raiz de
+  projetos consumidores.
+- Editar instrucoes proprietarias do projeto host.
+- Fechar ou atualizar automaticamente a issue externa no GitHub.
+- Alterar o modelo canonico de issues markdown (`yoda/project/issues/*.md`).
+
+## Requirements
+- `init.py` nao deve escrever, criar, anexar bloco ou fazer merge em arquivos de
+  agente/intent na raiz do projeto host.
+- Em modo `--dry-run`, `init.py` tambem nao deve reportar escrita planejada
+  nesses arquivos raiz.
+- O YODA deve manter sua documentacao operacional autocontida dentro de `yoda/`,
+  incluindo `yoda/AGENTS.md`, `yoda/GEMINI.md`, `yoda/CLAUDE.md` e
+  `yoda/yoda.md`.
+- `yoda/AGENTS.md`, `yoda/GEMINI.md` e `yoda/CLAUDE.md` devem ser curtos e devem
+  orientar a leitura de `yoda/yoda.md`, sem duplicar playbooks extensos.
+- `yoda/yoda.md` nao deve orientar leitura de `REPO_INTENT.md`.
+- A lista de arquivos empacotados deve incluir os novos arquivos autocontidos.
+- O update/package deve continuar substituindo arquivos de framework sob `yoda/`
+  sem tocar dados de projeto preservados.
+- A documentacao deve explicar que projetos host podem manter seus proprios
+  arquivos de agente e, se desejarem, apontar manualmente para `yoda/yoda.md`.
+- `project/specs/07-agent-entry-files.md` deve refletir que os arquivos
+  de entrada de agentes sao autocontidos sob `yoda/` e que `init.py` nao toca a
+  raiz do host.
+- `project/specs/23-distribution-and-packaging.md` deve incluir os arquivos de
+  agente autocontidos no contrato do artefato e remover expectativa de skeleton
+  raiz com `AGENTS.md`.
+- `project/specs/24-installation-and-upgrade.md` e runbooks de scripts devem ser
+  revisados para nao sugerir mutacao de arquivos raiz de agente/intent.
+
+## Acceptance criteria
+- [x] `init.py` nao cria nem modifica `AGENTS.md`, `GEMINI.md`, `CLAUDE.md`,
+      `REPO_INTENT.md` ou `repo.intent.yaml` na raiz do projeto host.
+- [x] Testes cobrem projeto vazio e projeto com arquivos de agente existentes,
+      validando que eles permanecem ausentes/inalterados.
+- [x] Existem `yoda/AGENTS.md`, `yoda/GEMINI.md` e `yoda/CLAUDE.md`, todos
+      autocontidos e apontando para `yoda/yoda.md`.
+- [x] `yoda/yoda.md` nao instrui agentes a ler `REPO_INTENT.md`.
+- [x] Package/update incluem ou preservam corretamente os arquivos autocontidos
+      de instrucao, sem depender de arquivos raiz do projeto host.
+- [x] README/manual/script help deixam claro que `init.py` e nao intrusivo em
+      relacao aos arquivos de agente/intent do projeto host.
+- [x] `project/specs/` foi revisado e atualizado nos contratos afetados.
+- [x] A suite relevante de testes passa.
+
+## Entry points
+- project/specs/07-agent-entry-files.md
+- project/specs/23-distribution-and-packaging.md
+- project/specs/24-installation-and-upgrade.md
+- project/specs/06-agent-playbook.md
+- project/specs/12-yoda-structure.md
+- yoda/scripts/init.py
+- yoda/scripts/tests/test_init.py
+- package.py
+- yoda/scripts/tests/test_package.py
+- yoda/scripts/update.py
+- yoda/yoda.md
+- yoda/AGENTS.md
+- yoda/GEMINI.md
+- yoda/CLAUDE.md
+- README.md
+- yoda/scripts/README.md
+- yoda/project/extern_issues/github-007.json
+
+## Implementation notes
+Tratar esta mudanca como alteracao de abordagem operacional, nao como migracao
+destrutiva. O comportamento novo deve ser forward-only: `init.py` deixa de tocar
+arquivos raiz daqui para frente, mas nao remove arquivos ja existentes.
+
+Decisao de Study:
+
+- Criar `yoda/AGENTS.md`, `yoda/GEMINI.md` e `yoda/CLAUDE.md`.
+- Nao criar `REPO_INTENT.md` nem `repo.intent.yaml` dentro de `yoda/`.
+- Remover integralmente do `init.py` a logica de escrita/merge para arquivos de
+  agente e intent da raiz do host.
+- Revisar docs/runbooks/scripts e `project/specs/` no mesmo trabalho.
+- Revisar empacotamento para incluir os novos arquivos autocontidos.
+
+Evitar duplicar instrucoes longas nos novos arquivos de agente. Eles devem atuar
+como roteadores autocontidos para `yoda/yoda.md`.
+
+## Tests
+Atualizar testes de `init.py` que hoje esperam criacao/alteracao de arquivos
+raiz. Adicionar regressao para garantir que arquivos de agente existentes no host
+nao sao alterados e que, em projeto vazio, esses arquivos nao sao criados.
+
+Adicionar ou ajustar testes de empacotamento/update para confirmar que
+`yoda/AGENTS.md`, `yoda/GEMINI.md` e `yoda/CLAUDE.md` entram no artefato e sao
+tratados como arquivos de framework substituiveis.
+
+## Risks and edge cases
+- Projetos host que dependiam do bloco automatico em `AGENTS.md` deixam de
+  receber esse onboarding automatico.
+- Documentacao pode ficar ambigua se ainda mencionar que `init.py` altera
+  arquivos raiz.
+- O pacote pode ficar incompleto se novos arquivos autocontidos nao entrarem no
+  manifesto/arquivo distribuivel.
+- Mudancas em `init.py` nao devem afetar preservacao de dados YODA como
+  `yoda/project/issues/` e `yoda/project/extern_issues/`.
+- Specs antigas podem continuar descrevendo `init.py` como criador de
+  `AGENTS.md` na raiz se a revisao de `project/specs/` nao for completa.
+
+## Result log
+fix(yoda): stop init from mutating host agent files
+
+`init.py` deixou de criar, atualizar ou mesclar arquivos de agente/intent na raiz
+do projeto host. O YODA agora carrega entradas autocontidas em `yoda/AGENTS.md`,
+`yoda/GEMINI.md` e `yoda/CLAUDE.md`, com documentacao operacional apontando para
+`yoda/yoda.md`, specs/runbooks alinhados e empacotamento cobrindo os novos
+arquivos.
+
+- **GitHub Issue** :   #007
+
+- **Issue**: `yoda-0063`
+
+- **Path**: `yoda/project/issues/yoda-0063-tornar-init-py-n-o-intrusivo-para-arquivos-de-agente.md`
+
+## Flow log
+- 2026-06-02T09:09:50-03:00 issue_add created title=Tornar init.py não intrusivo para arquivos de agente; priority=5
+- 2026-06-02T09:14:02-03:00 transition to-do->doing/study
+- 2026-06-02T09:20:11-03:00 transition doing/study->doing/document | Study approved: create yoda/AGENTS.md GEMINI.md CLAUDE.md, remove host root agent/intent mutations from init.py, update yoda.md, docs/runbooks, project specs, and packaging
+- 2026-06-02T09:22:22-03:00 transition doing/document->doing/implement | Document approved: implement non-intrusive init, yoda-local agent files, yoda.md entry update, project specs/docs, packaging, and tests
+- 2026-06-02T09:32:54-03:00 transition doing/implement->doing/evaluate | Implement completed: init is non-intrusive for host-root agent/intent files, YODA-local agent entries were added, docs/specs/package/tests were updated, and spec 07 was renamed to agent-entry-files before evaluation
+- 2026-06-02T10:19:33-03:00 transition doing/evaluate->done | Evaluate approved: acceptance criteria validated, result log filled, and test suite passed with 68 tests

--- a/yoda/scripts/README.md
+++ b/yoda/scripts/README.md
@@ -39,6 +39,9 @@ python yoda/scripts/log_add.py --dev dev --issue dev-0001 --message "Additional 
 
 ## Init in a host project
 
+`init.py` manages YODA-owned structure under `yoda/`; it does not create or edit
+host-root agent or intent files.
+
 ```bash
 python yoda/scripts/init.py --dev <slug>
 python yoda/scripts/init.py --dev <slug> --root /path/to/project --dry-run

--- a/yoda/scripts/README.md
+++ b/yoda/scripts/README.md
@@ -1,6 +1,10 @@
 # yoda/scripts
 
-Operational scripts for the YODA Framework (issue-markdown-driven flow). Primary reference: `project/specs/13-yoda-scripts-v1.md`.
+Operational scripts for the YODA Framework (issue-markdown-driven flow).
+
+This directory is self-contained for embedded YODA usage. For operational details,
+read each command's `--help` output and follow the Agent guidance/runbook printed
+by the command.
 
 ## Quick rules
 

--- a/yoda/scripts/README.md
+++ b/yoda/scripts/README.md
@@ -22,6 +22,7 @@ pip install -r yoda/scripts/requirements.txt
 
 python yoda/scripts/yoda_flow_next.py --dev dev
 python yoda/scripts/yoda_flow_next.py --dev dev --log-message "Study completed"
+python yoda/scripts/yoda_prep_flow.py --dev dev --issue dev-0001
 python yoda/scripts/yoda_intake.py --dev dev
 python yoda/scripts/get_extern_issue.py --dev dev --extern-issue 123
 python yoda/scripts/todo_update.py --dev dev --issue dev-0001 --status doing --phase study
@@ -31,6 +32,7 @@ python yoda/scripts/log_add.py --dev dev --issue dev-0001 --message "Additional 
 ## Flow and Intake
 
 - Deterministic YODA Flow: `yoda_flow_next.py`
+- Explicit issue Study/Document preparation: `yoda_prep_flow.py`
 - Intake runbooks: `yoda_intake.py`
 - Manual semantic/process adjustments: `todo_update.py`
 - Exceptional manual logging: `log_add.py`

--- a/yoda/scripts/init.py
+++ b/yoda/scripts/init.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import difflib
 import logging
 import sys
 from pathlib import Path
@@ -38,31 +37,6 @@ except Exception as exc:  # pragma: no cover - runtime dependency
     ) from exc
 
 
-AGENT_FILES = ["AGENTS.md", "GEMINI.md", "CLAUDE.md"]
-REPO_INTENT_FILE = "REPO_INTENT.md"
-REPO_INTENT_YAML = "repo.intent.yaml"
-REPO_INTENT_HEADER = "# Repository Intent\n\nThis repository embeds the YODA Framework.\n"
-YODA_BLOCK = (
-    "<!-- YODA:BEGIN -->\n"
-    "## YODA Framework\n\n"
-    "Read in order:\n\n"
-    "1) yoda/yoda.md\n"
-    "<!-- YODA:END -->\n"
-)
-REPO_INTENT_BLOCK = (
-    "<!-- YODA:BEGIN -->\n"
-    "## YODA Framework\n\n"
-    "Read in order:\n\n"
-    "1) REPO_INTENT.md\n"
-    "2) yoda/yoda.md\n"
-    "<!-- YODA:END -->\n"
-)
-REPO_INTENT_YODA_DEFAULT = {
-    "embedded": True,
-    "manual": "yoda/yoda.md",
-    "agent_entry_order": ["REPO_INTENT.md", "yoda/yoda.md"],
-}
-DIFF_LIMIT = 40
 SCHEMA_VERSION = "2.00"
 
 
@@ -278,67 +252,6 @@ def _sanitize_issue_front_matter_ids(
     return written, skipped
 
 
-def _diff_summary(expected: str, existing: str, label: str) -> list[str]:
-    diff = list(
-        difflib.unified_diff(
-            expected.splitlines(),
-            existing.splitlines(),
-            fromfile=f"{label} (expected)",
-            tofile=f"{label} (existing)",
-            lineterm="",
-        )
-    )
-    if len(diff) > DIFF_LIMIT:
-        return diff[:DIFF_LIMIT] + ["... (diff truncated)"]
-    return diff
-
-
-def _append_block(existing: str, block: str) -> str:
-    if not existing.strip():
-        return block
-    return existing.rstrip("\n") + "\n\n" + block
-
-
-def _upsert_block(existing: str, block: str) -> tuple[str, str, str | None]:
-    begin = "<!-- YODA:BEGIN -->"
-    end = "<!-- YODA:END -->"
-    start = existing.find(begin)
-    if start == -1:
-        return _append_block(existing, block), "appended", None
-    end_pos = existing.find(end, start)
-    if end_pos == -1:
-        return existing, "conflict", "missing YODA:END marker"
-    tail_start = end_pos + len(end)
-    extra_begin = existing.find(begin, tail_start)
-    if extra_begin != -1:
-        return existing, "conflict", "multiple YODA blocks found"
-    current_block = existing[start:tail_start]
-    if current_block.strip("\n") == block.strip("\n"):
-        return existing, "unchanged", None
-    updated = existing[:start] + block + existing[tail_start:]
-    return updated, "updated", None
-
-
-def _merge_repo_intent(data: dict[str, Any]) -> tuple[dict[str, Any], bool, str | None]:
-    yoda_section = data.get("yoda")
-    if yoda_section is None:
-        updated = dict(data)
-        updated["yoda"] = dict(REPO_INTENT_YODA_DEFAULT)
-        return updated, True, None
-    if not isinstance(yoda_section, dict):
-        return data, False, "yoda section is not a mapping"
-
-    changed = False
-    updated = dict(data)
-    merged_section = dict(yoda_section)
-    for key, value in REPO_INTENT_YODA_DEFAULT.items():
-        if key not in merged_section:
-            merged_section[key] = value
-            changed = True
-    updated["yoda"] = merged_section
-    return updated, changed, None
-
-
 def _render_output(payload: dict[str, Any], output_format: str) -> str:
     lines = [
         f"Root: {payload['root']}",
@@ -360,14 +273,6 @@ def _render_output(payload: dict[str, Any], output_format: str) -> str:
         for item in payload["files_skipped"]:
             lines.append(f"- {item}")
 
-    conflicts = payload.get("conflicts", [])
-    if conflicts:
-        lines.append("Conflicts:")
-        for item in conflicts:
-            lines.append(f"- {item['path']}: {item['reason']}")
-            for diff_line in item.get("diff", []):
-                lines.append(diff_line)
-
     return render_output(payload, output_format, lines, dry_run=bool(payload.get("dry_run")))
 
 
@@ -379,7 +284,9 @@ def main() -> int:
             "Agent guidance:\n"
             "- Purpose: prepare/reconcile a host project with embedded YODA structure and metadata.\n"
             "- When to use: after install/update, or to reconcile legacy files with current schema.\n"
-            "- Mutability: creates/updates project files and may migrate/remove legacy TODO/log YAML."
+            "- Mutability: creates/updates only YODA-managed files under yoda/ and may\n"
+            "  migrate/remove legacy TODO/log YAML. It does not create or edit host-root\n"
+            "  agent or intent files."
         ),
     )
     add_global_flags(parser)
@@ -419,7 +326,6 @@ def main() -> int:
         dirs_created: list[str] = []
         files_written: list[str] = []
         files_skipped: list[str] = []
-        conflicts: list[dict[str, Any]] = []
         exit_code = ExitCode.SUCCESS
 
         for path in dirs:
@@ -433,181 +339,6 @@ def main() -> int:
             if not args.dry_run:
                 path.mkdir(parents=True, exist_ok=True)
             dirs_created.append(str(path.relative_to(root)))
-
-        for filename in AGENT_FILES:
-            agents_path = root / filename
-            if agents_path.exists():
-                if agents_path.is_dir():
-                    conflicts.append(
-                        {
-                            "path": filename,
-                            "reason": "path exists and is a directory",
-                            "diff": [],
-                        }
-                    )
-                    files_skipped.append(f"{filename} (kept)")
-                    exit_code = ExitCode.CONFLICT
-                    continue
-                try:
-                    existing = agents_path.read_text(encoding="utf-8")
-                except OSError:
-                    conflicts.append(
-                        {
-                            "path": filename,
-                            "reason": "unreadable file",
-                            "diff": [],
-                        }
-                    )
-                    files_skipped.append(f"{filename} (kept)")
-                    exit_code = ExitCode.CONFLICT
-                    continue
-
-                updated, status, reason = _upsert_block(existing, YODA_BLOCK)
-                if status == "conflict":
-                    conflicts.append(
-                        {
-                            "path": filename,
-                            "reason": reason or "invalid YODA block",
-                            "diff": [],
-                        }
-                    )
-                    files_skipped.append(f"{filename} (kept)")
-                    exit_code = ExitCode.CONFLICT
-                elif status == "unchanged":
-                    files_skipped.append(f"{filename} (unchanged)")
-                else:
-                    if not args.dry_run:
-                        agents_path.write_text(updated, encoding="utf-8")
-                    action = "updated" if status == "updated" else "appended"
-                    files_written.append(f"{filename} ({action})")
-            else:
-                if not args.dry_run:
-                    agents_path.write_text(YODA_BLOCK, encoding="utf-8")
-                files_written.append(f"{filename} (created)")
-
-        intent_path = root / REPO_INTENT_FILE
-        if intent_path.exists():
-            if intent_path.is_dir():
-                conflicts.append(
-                    {
-                        "path": REPO_INTENT_FILE,
-                        "reason": "path exists and is a directory",
-                        "diff": [],
-                    }
-                )
-                files_skipped.append(f"{REPO_INTENT_FILE} (kept)")
-                exit_code = ExitCode.CONFLICT
-            else:
-                try:
-                    existing = intent_path.read_text(encoding="utf-8")
-                except OSError:
-                    conflicts.append(
-                        {
-                            "path": REPO_INTENT_FILE,
-                            "reason": "unreadable file",
-                            "diff": [],
-                        }
-                    )
-                    files_skipped.append(f"{REPO_INTENT_FILE} (kept)")
-                    exit_code = ExitCode.CONFLICT
-                else:
-                    updated, status, reason = _upsert_block(existing, REPO_INTENT_BLOCK)
-                    if status == "conflict":
-                        conflicts.append(
-                            {
-                                "path": REPO_INTENT_FILE,
-                                "reason": reason or "invalid YODA block",
-                                "diff": [],
-                            }
-                        )
-                        files_skipped.append(f"{REPO_INTENT_FILE} (kept)")
-                        exit_code = ExitCode.CONFLICT
-                    elif status == "unchanged":
-                        files_skipped.append(f"{REPO_INTENT_FILE} (unchanged)")
-                    else:
-                        if not args.dry_run:
-                            intent_path.write_text(updated, encoding="utf-8")
-                        action = "updated" if status == "updated" else "appended"
-                        files_written.append(f"{REPO_INTENT_FILE} ({action})")
-        else:
-            content = _append_block(REPO_INTENT_HEADER, REPO_INTENT_BLOCK)
-            if not args.dry_run:
-                intent_path.write_text(content, encoding="utf-8")
-            files_written.append(f"{REPO_INTENT_FILE} (created)")
-
-        intent_yaml_path = root / REPO_INTENT_YAML
-        if intent_yaml_path.exists():
-            if intent_yaml_path.is_dir():
-                conflicts.append(
-                    {
-                        "path": REPO_INTENT_YAML,
-                        "reason": "path exists and is a directory",
-                        "diff": [],
-                    }
-                )
-                files_skipped.append(f"{REPO_INTENT_YAML} (kept)")
-                exit_code = ExitCode.CONFLICT
-            else:
-                try:
-                    raw = intent_yaml_path.read_text(encoding="utf-8")
-                    data = yaml.safe_load(raw)
-                except Exception:
-                    conflicts.append(
-                        {
-                            "path": REPO_INTENT_YAML,
-                            "reason": "invalid YAML",
-                            "diff": [],
-                        }
-                    )
-                    files_skipped.append(f"{REPO_INTENT_YAML} (kept)")
-                    exit_code = ExitCode.CONFLICT
-                else:
-                    if data is None:
-                        data = {}
-                    if not isinstance(data, dict):
-                        conflicts.append(
-                            {
-                                "path": REPO_INTENT_YAML,
-                                "reason": "YAML root is not a mapping",
-                                "diff": [],
-                            }
-                        )
-                        files_skipped.append(f"{REPO_INTENT_YAML} (kept)")
-                        exit_code = ExitCode.CONFLICT
-                    else:
-                        merged, changed, reason = _merge_repo_intent(data)
-                        if reason:
-                            conflicts.append(
-                                {
-                                    "path": REPO_INTENT_YAML,
-                                    "reason": reason,
-                                    "diff": [],
-                                }
-                            )
-                            files_skipped.append(f"{REPO_INTENT_YAML} (kept)")
-                            exit_code = ExitCode.CONFLICT
-                        elif not changed:
-                            files_skipped.append(f"{REPO_INTENT_YAML} (unchanged)")
-                        else:
-                            if not args.dry_run:
-                                intent_yaml_path.write_text(
-                                    yaml.safe_dump(
-                                        merged, sort_keys=False, allow_unicode=False
-                                    ),
-                                    encoding="utf-8",
-                                )
-                            files_written.append(f"{REPO_INTENT_YAML} (updated)")
-        else:
-            if not args.dry_run:
-                intent_yaml_path.write_text(
-                    yaml.safe_dump(
-                        {"yoda": REPO_INTENT_YODA_DEFAULT},
-                        sort_keys=False,
-                        allow_unicode=False,
-                    ),
-                    encoding="utf-8",
-                )
-            files_written.append(f"{REPO_INTENT_YAML} (created)")
 
         migrated_written, migrated_skipped = _migrate_legacy_workspace(
             root=root,
@@ -642,7 +373,6 @@ def main() -> int:
             "dirs_created": dirs_created,
             "files_written": files_written,
             "files_skipped": files_skipped,
-            "conflicts": conflicts,
             "dry_run": bool(args.dry_run),
         }
 

--- a/yoda/scripts/lib/issue_index.py
+++ b/yoda/scripts/lib/issue_index.py
@@ -21,6 +21,7 @@ except Exception as exc:  # pragma: no cover - runtime dependency
 
 
 ALLOWED_PHASE = {"study", "document", "implement", "evaluate"}
+ALLOWED_FLOW_PREPARED_UNTIL = {"study", "document"}
 DEFAULT_SCHEMA_VERSIONS = {"2.00"}
 
 
@@ -104,6 +105,19 @@ def _normalize_phase(metadata: dict[str, Any], status: str, path: Path, issue_id
     return phase_value
 
 
+def _normalize_flow_prepared_until(metadata: dict[str, Any], path: Path, issue_id: str) -> str:
+    value = metadata.get("flow_prepared_until")
+    if value in (None, ""):
+        return ""
+    normalized = str(value).strip().lower()
+    if normalized not in ALLOWED_FLOW_PREPARED_UNTIL:
+        raise YodaError(
+            f"{path}: {issue_id}: invalid 'flow_prepared_until' value '{normalized}'",
+            exit_code=ExitCode.VALIDATION,
+        )
+    return normalized
+
+
 def _build_issue_record(
     path: Path,
     dev: str,
@@ -141,6 +155,7 @@ def _build_issue_record(
         "path": str(path),
         "status": status,
         "phase": _normalize_phase(metadata, status, path, issue_id),
+        "flow_prepared_until": _normalize_flow_prepared_until(metadata, path, issue_id),
         "depends_on": _normalize_depends_on(metadata, path, issue_id),
         "title": _require_string(metadata, "title", path, issue_id),
         "description": _require_string(metadata, "description", path, issue_id),

--- a/yoda/scripts/lib/issue_metadata.py
+++ b/yoda/scripts/lib/issue_metadata.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 from typing import Any
 
 
-OPTIONAL_EMPTY_KEYS = ("phase", "depends_on", "pending_reason", "extern_issue_file")
+OPTIONAL_EMPTY_KEYS = (
+    "phase",
+    "flow_prepared_until",
+    "depends_on",
+    "pending_reason",
+    "extern_issue_file",
+)
 CANONICAL_ISSUE_FIELD_ORDER = (
     "schema_version",
     "id",
     "status",
     "phase",
+    "flow_prepared_until",
     "pending_reason",
     "depends_on",
     "title",

--- a/yoda/scripts/tests/test_cli_contracts.py
+++ b/yoda/scripts/tests/test_cli_contracts.py
@@ -14,6 +14,7 @@ def test_help_contains_agent_guidance_for_all_scripts() -> None:
         "todo_update.py",
         "update.py",
         "yoda_flow_next.py",
+        "yoda_prep_flow.py",
         "yoda_intake.py",
     ]
     for script in scripts:
@@ -40,6 +41,7 @@ def test_commands_require_explicit_dev_without_env_or_prompt(monkeypatch) -> Non
         ("todo_next.py", []),
         ("todo_update.py", ["--issue", "test-0001"]),
         ("yoda_flow_next.py", []),
+        ("yoda_prep_flow.py", ["--issue", "test-0001"]),
     ]
     for script, args in commands:
         result = run_script(script, args)

--- a/yoda/scripts/tests/test_init.py
+++ b/yoda/scripts/tests/test_init.py
@@ -20,9 +20,43 @@ def test_init_creates_structure_without_todo_file(tmp_path: Path) -> None:
     _seed_manual(tmp_path)
     result = run_script("init.py", ["--dev", TEST_DEV, "--root", str(tmp_path)])
     assert result.returncode == 0, result.stderr
-    assert (tmp_path / "AGENTS.md").exists()
+    assert not (tmp_path / "AGENTS.md").exists()
+    assert not (tmp_path / "GEMINI.md").exists()
+    assert not (tmp_path / "CLAUDE.md").exists()
+    assert not (tmp_path / "REPO_INTENT.md").exists()
+    assert not (tmp_path / "repo.intent.yaml").exists()
     assert (tmp_path / "yoda" / "project" / "issues").exists()
     assert not (tmp_path / "yoda" / "todos" / f"TODO.{TEST_DEV}.yaml").exists()
+
+
+def test_init_does_not_modify_existing_host_agent_or_intent_files(tmp_path: Path) -> None:
+    _seed_manual(tmp_path)
+    existing_files = {
+        "AGENTS.md": "# Host agents\n",
+        "GEMINI.md": "# Host gemini\n",
+        "CLAUDE.md": "# Host claude\n",
+        "REPO_INTENT.md": "# Host intent\n",
+        "repo.intent.yaml": "project: host\n",
+    }
+    for name, content in existing_files.items():
+        (tmp_path / name).write_text(content, encoding="utf-8")
+
+    result = run_script("init.py", ["--dev", TEST_DEV, "--root", str(tmp_path)])
+    assert result.returncode == 0, result.stderr
+
+    for name, content in existing_files.items():
+        assert (tmp_path / name).read_text(encoding="utf-8") == content
+
+
+def test_init_dry_run_does_not_report_host_agent_or_intent_writes(tmp_path: Path) -> None:
+    _seed_manual(tmp_path)
+    result = run_script("init.py", ["--dev", TEST_DEV, "--root", str(tmp_path), "--dry-run"])
+    assert result.returncode == 0, result.stderr
+    assert "AGENTS.md" not in result.stdout
+    assert "GEMINI.md" not in result.stdout
+    assert "CLAUDE.md" not in result.stdout
+    assert "REPO_INTENT.md" not in result.stdout
+    assert "repo.intent.yaml" not in result.stdout
 
 
 def test_init_sanitizes_existing_issue_front_matter_id_without_legacy_todo(tmp_path: Path) -> None:

--- a/yoda/scripts/tests/test_package.py
+++ b/yoda/scripts/tests/test_package.py
@@ -70,6 +70,9 @@ def test_package_builds_and_excludes_tests(tmp_path: Path) -> None:
         assert "LICENSE" in names
         assert "yoda/LICENSE" in names
         assert "yoda/yoda.md" in names
+        assert "yoda/AGENTS.md" in names
+        assert "yoda/GEMINI.md" in names
+        assert "yoda/CLAUDE.md" in names
         assert "yoda/PACKAGE_MANIFEST.yaml" in names
         assert "CHANGELOG.yaml" in names
         assert not any(name.startswith("yoda/scripts/tests") for name in names)

--- a/yoda/scripts/tests/test_package.py
+++ b/yoda/scripts/tests/test_package.py
@@ -75,6 +75,20 @@ def test_package_builds_and_excludes_tests(tmp_path: Path) -> None:
         assert not any(name.startswith("yoda/scripts/tests") for name in names)
         assert not any(name.startswith("yoda/favicons/") for name in names)
         assert not any(name.startswith("favicons/") for name in names)
+
+        packaged_text = ""
+        with tarfile.open(output_path, "r:gz") as tar:
+            for member in tar.getmembers():
+                if not member.isfile():
+                    continue
+                if not member.name.endswith((".md", ".py", ".txt", ".yaml", ".yml", ".json")):
+                    continue
+                extracted = tar.extractfile(member)
+                if extracted is None:
+                    continue
+                packaged_text += extracted.read().decode("utf-8")
+
+        assert "project/specs" not in packaged_text
     finally:
         _restore_file(changelog_path, changelog_backup)
         _restore_file(latest_json_path, latest_backup)

--- a/yoda/scripts/tests/test_yoda_flow_next.py
+++ b/yoda/scripts/tests/test_yoda_flow_next.py
@@ -95,6 +95,38 @@ def test_flow_next_transitions_todo_to_doing_study_and_logs() -> None:
     assert _last_log_line(path).endswith("transition to-do->doing/study")
 
 
+def test_flow_next_starts_prepared_issue_at_implement() -> None:
+    path = _write_issue_file(
+        "test-0001-prepared.md",
+        {
+            "schema_version": "2.00",
+            "status": "to-do",
+            "flow_prepared_until": "document",
+            "title": "Prepared",
+            "description": "Desc",
+            "priority": 5,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        },
+        body="# Prepared\n\n## Flow log\n",
+    )
+
+    result = run_script("yoda_flow_next.py", ["--dev", TEST_DEV, "--format", "json"])
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["issue_id"] == "test-0001"
+    assert payload["status"] == "doing"
+    assert payload["phase"] == "implement"
+    assert payload["next_step"] == "implement"
+    assert payload["runbook_line"].startswith("Run Implement:")
+
+    meta = _read_front_matter(path)
+    assert meta["status"] == "doing"
+    assert meta["phase"] == "implement"
+    assert meta["flow_prepared_until"] == "document"
+    assert _last_log_line(path).endswith("transition to-do->doing/implement | prepared_until=document")
+
+
 def test_flow_next_advances_doing_phases_and_finishes_done() -> None:
     path = _write_issue_file(
         "test-0001-doing.md",

--- a/yoda/scripts/tests/test_yoda_prep_flow.py
+++ b/yoda/scripts/tests/test_yoda_prep_flow.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import frontmatter
+
+from conftest import REPO_ROOT, TEST_DEV, cleanup_test_files, run_script
+
+
+def _write_issue_file(name: str, front_matter: dict[str, object], body: str = "# Test\n") -> Path:
+    path = REPO_ROOT / "yoda" / "project" / "issues" / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["---"]
+    for key, value in front_matter.items():
+        if isinstance(value, list):
+            lines.append(f"{key}:")
+            for item in value:
+                lines.append(f"- {item}")
+        elif isinstance(value, int):
+            lines.append(f"{key}: {value}")
+        else:
+            lines.append(f"{key}: '{value}'")
+    lines.extend(["---", "", body.rstrip("\n"), ""])
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def _read_front_matter(path: Path) -> dict:
+    return dict(frontmatter.load(path).metadata)
+
+
+def _read_flow_log_lines(path: Path) -> list[str]:
+    text = path.read_text(encoding="utf-8")
+    match = re.search(r"(?m)^## Flow log\s*$", text)
+    assert match is not None
+    section = text[match.end() :]
+    next_header = re.search(r"(?m)^##\s+", section)
+    if next_header:
+        section = section[: next_header.start()]
+    return [line for line in section.splitlines() if line.strip()]
+
+
+def _last_log_line(path: Path) -> str:
+    lines = _read_flow_log_lines(path)
+    assert lines
+    return lines[-1]
+
+
+def setup_function() -> None:
+    cleanup_test_files()
+
+
+def teardown_function() -> None:
+    cleanup_test_files()
+
+
+def test_prep_flow_requires_explicit_dev_slug() -> None:
+    result = run_script("yoda_prep_flow.py", ["--issue", "test-0001"])
+    assert result.returncode == 2
+    assert "--dev is required" in result.stderr
+
+
+def test_prep_flow_help_contains_agent_guidance() -> None:
+    result = run_script("yoda_prep_flow.py", ["--help"])
+    assert result.returncode == 0
+    assert "Agent guidance:" in result.stdout
+
+
+def test_prep_flow_targets_explicit_issue_and_ignores_priority_order() -> None:
+    _write_issue_file(
+        "test-0001-high-priority.md",
+        {
+            "schema_version": "2.00",
+            "status": "to-do",
+            "title": "High",
+            "description": "Desc",
+            "priority": 10,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        },
+        body="# High\n\n## Flow log\n",
+    )
+    target = _write_issue_file(
+        "test-0002-target.md",
+        {
+            "schema_version": "2.00",
+            "status": "to-do",
+            "title": "Target",
+            "description": "Desc",
+            "priority": 1,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        },
+        body="# Target\n\n## Flow log\n",
+    )
+
+    result = run_script(
+        "yoda_prep_flow.py",
+        ["--dev", TEST_DEV, "--issue", "test-0002", "--format", "json"],
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["issue_id"] == "test-0002"
+    assert payload["status"] == "to-do"
+    assert payload["flow_prepared_until"] == "study"
+    assert payload["next_step"] == "study"
+    assert payload["runbook_line"].startswith("Run Prep Study:")
+
+    meta = _read_front_matter(target)
+    assert meta["status"] == "to-do"
+    assert "phase" not in meta
+    assert meta["flow_prepared_until"] == "study"
+    assert _last_log_line(target).endswith("prep transition prepared_until=none->study")
+
+
+def test_prep_flow_advances_to_document_and_keeps_issue_todo() -> None:
+    target = _write_issue_file(
+        "test-0001-target.md",
+        {
+            "schema_version": "2.00",
+            "status": "to-do",
+            "flow_prepared_until": "study",
+            "title": "Target",
+            "description": "Desc",
+            "priority": 5,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        },
+        body="# Target\n\n## Flow log\n",
+    )
+
+    result = run_script(
+        "yoda_prep_flow.py",
+        ["--dev", TEST_DEV, "--issue", "test-0001", "--format", "json"],
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["flow_prepared_until"] == "document"
+    assert payload["next_step"] == "document"
+    assert payload["runbook_line"].startswith("Run Prep Document:")
+
+    meta = _read_front_matter(target)
+    assert meta["status"] == "to-do"
+    assert "phase" not in meta
+    assert meta["flow_prepared_until"] == "document"
+    assert _last_log_line(target).endswith("prep transition prepared_until=study->document")
+
+
+def test_prep_flow_dry_run_does_not_write() -> None:
+    target = _write_issue_file(
+        "test-0001-dry-run.md",
+        {
+            "schema_version": "2.00",
+            "status": "to-do",
+            "title": "Dry",
+            "description": "Desc",
+            "priority": 5,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        },
+        body="# Dry\n\n## Flow log\n",
+    )
+    before = target.read_text(encoding="utf-8")
+
+    result = run_script(
+        "yoda_prep_flow.py",
+        ["--dev", TEST_DEV, "--issue", "test-0001", "--dry-run", "--format", "json"],
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["flow_prepared_until"] == "study"
+    assert target.read_text(encoding="utf-8") == before
+    assert _read_flow_log_lines(target) == []
+
+
+def test_prep_flow_rejects_done_issue() -> None:
+    _write_issue_file(
+        "test-0001-done.md",
+        {
+            "schema_version": "2.00",
+            "status": "done",
+            "title": "Done",
+            "description": "Desc",
+            "priority": 5,
+            "created_at": "2026-01-01T00:00:00+00:00",
+            "updated_at": "2026-01-01T00:00:00+00:00",
+        },
+        body="# Done\n\n## Flow log\n",
+    )
+
+    result = run_script("yoda_prep_flow.py", ["--dev", TEST_DEV, "--issue", "test-0001"])
+    assert result.returncode == 2
+    assert "cannot run on done issues" in result.stderr

--- a/yoda/scripts/yoda_flow_next.py
+++ b/yoda/scripts/yoda_flow_next.py
@@ -37,6 +37,7 @@ RUNBOOK_BY_STEP = {
 RUNBOOK_DONE = "Issue moved to done. Check next issue and ask the human if flow should continue now."
 STEP_ORDER = ("study", "document", "implement", "evaluate")
 NEXT_PHASE = {"study": "document", "document": "implement", "implement": "evaluate", "evaluate": ""}
+PREPARED_UNTIL_DOCUMENT = "document"
 
 
 def _relative(path_value: str) -> str:
@@ -126,20 +127,28 @@ def _load_issue_front_matter(issue: dict[str, Any]) -> tuple[Path, dict[str, Any
 def _apply_transition(issue: dict[str, Any], log_message: str = "") -> dict[str, Any]:
     status = str(issue.get("status", "")).strip()
     phase = str(issue.get("phase") or "").strip().lower()
+    flow_prepared_until = str(issue.get("flow_prepared_until") or "").strip().lower()
     issue_path, metadata = _load_issue_front_matter(issue)
     ts = _now_ts()
 
     if status == "to-do":
         metadata["status"] = "doing"
-        metadata["phase"] = "study"
+        if flow_prepared_until == PREPARED_UNTIL_DOCUMENT:
+            metadata["phase"] = "implement"
+            transition_log = "transition to-do->doing/implement | prepared_until=document"
+            next_step = "implement"
+        else:
+            metadata["phase"] = "study"
+            transition_log = "transition to-do->doing/study"
+            next_step = "study"
         metadata["updated_at"] = ts
         update_front_matter(issue_path, metadata)
-        log_ts = _append_log(issue, _compose_transition_log("transition to-do->doing/study", log_message))
+        log_ts = _append_log(issue, _compose_transition_log(transition_log, log_message))
         return {
             "status": "doing",
-            "phase": "study",
-            "next_step": "study",
-            "runbook_line": RUNBOOK_BY_STEP["study"],
+            "phase": next_step,
+            "next_step": next_step,
+            "runbook_line": RUNBOOK_BY_STEP[next_step],
             "log_timestamp": log_ts,
         }
 
@@ -192,14 +201,16 @@ def _apply_transition(issue: dict[str, Any], log_message: str = "") -> dict[str,
 def _simulate_transition(issue: dict[str, Any]) -> dict[str, Any]:
     status = str(issue.get("status", "")).strip()
     phase = str(issue.get("phase") or "").strip().lower()
+    flow_prepared_until = str(issue.get("flow_prepared_until") or "").strip().lower()
     ts = _now_ts()
 
     if status == "to-do":
+        next_step = "implement" if flow_prepared_until == PREPARED_UNTIL_DOCUMENT else "study"
         return {
             "status": "doing",
-            "phase": "study",
-            "next_step": "study",
-            "runbook_line": RUNBOOK_BY_STEP["study"],
+            "phase": next_step,
+            "next_step": next_step,
+            "runbook_line": RUNBOOK_BY_STEP[next_step],
             "log_timestamp": ts,
         }
 

--- a/yoda/scripts/yoda_prep_flow.py
+++ b/yoda/scripts/yoda_prep_flow.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Run YODA Prep Flow for one issue without entering implementation."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+from typing import Any
+
+import frontmatter
+
+from lib.cli import add_global_flags, resolve_format
+from lib.errors import ExitCode, YodaError
+from lib.flow_log import append_flow_log_line, sanitize_flow_message
+from lib.front_matter import update_front_matter
+from lib.issue_metadata import canonicalize_issue_metadata
+from lib.issue_utils import resolve_issue_file_by_id
+from lib.logging_utils import configure_logging
+from lib.output import render_output
+from lib.paths import repo_root
+from lib.time_utils import detect_local_timezone, now_iso
+from lib.validate import validate_issue_id, validate_slug
+
+
+ALLOWED_PREPARED_UNTIL = {"", "study", "document"}
+NEXT_PREP_STEP = {"": "study", "study": "document", "document": "document"}
+RUNBOOK_BY_STEP = {
+    "study": "Run Prep Study: gather context and list open decisions for this issue; do not implement.",
+    "document": "Run Prep Document: update issue text with approved decisions; do not implement.",
+}
+
+
+def _relative(path_value: Path) -> str:
+    try:
+        return str(path_value.relative_to(repo_root()))
+    except ValueError:
+        return str(path_value)
+
+
+def _now_ts() -> str:
+    return now_iso(detect_local_timezone())
+
+
+def _load_issue(issue_id: str) -> tuple[Path, dict[str, Any]]:
+    issue_path = resolve_issue_file_by_id(issue_id)
+    post = frontmatter.load(str(issue_path))
+    metadata = dict(post.metadata)
+    schema_version = str(metadata.get("schema_version", "")).strip()
+    if schema_version != "2.00":
+        raise YodaError(
+            f"Unsupported schema_version '{schema_version}'. Run init.py migration first.",
+            exit_code=ExitCode.VALIDATION,
+        )
+    return issue_path, metadata
+
+
+def _prepared_until(metadata: dict[str, Any]) -> str:
+    prepared = str(metadata.get("flow_prepared_until") or "").strip().lower()
+    if prepared not in ALLOWED_PREPARED_UNTIL:
+        raise YodaError(
+            f"Invalid flow_prepared_until '{prepared}'. Expected study or document.",
+            exit_code=ExitCode.VALIDATION,
+        )
+    return prepared
+
+
+def _append_log(issue_path: Path, message: str, dry_run: bool) -> str:
+    timestamp = _now_ts()
+    if not dry_run:
+        append_flow_log_line(issue_path, f"{timestamp} {sanitize_flow_message(message)}")
+    return timestamp
+
+
+def _apply_prep_step(issue_path: Path, metadata: dict[str, Any], dry_run: bool) -> dict[str, Any]:
+    status = str(metadata.get("status", "")).strip()
+    if status == "done":
+        raise YodaError("YODA Prep Flow cannot run on done issues.", exit_code=ExitCode.VALIDATION)
+
+    current = _prepared_until(metadata)
+    next_step = NEXT_PREP_STEP[current]
+    timestamp = _now_ts()
+
+    updated = dict(metadata)
+    updated["status"] = "to-do"
+    updated.pop("phase", None)
+    updated["flow_prepared_until"] = next_step
+    updated["updated_at"] = timestamp
+    normalized = canonicalize_issue_metadata(updated)
+
+    if not dry_run:
+        update_front_matter(issue_path, normalized)
+
+    if current == "document":
+        log_message = "prep already prepared_until=document"
+    else:
+        log_message = f"prep transition prepared_until={current or 'none'}->{next_step}"
+    log_timestamp = _append_log(issue_path, log_message, dry_run)
+
+    return {
+        "status": "to-do",
+        "phase": "",
+        "flow_prepared_until": next_step,
+        "next_step": next_step,
+        "runbook_line": RUNBOOK_BY_STEP[next_step],
+        "log_timestamp": log_timestamp,
+    }
+
+
+def _render_md(payload: dict[str, Any]) -> list[str]:
+    lines = [
+        f"Issue ID: {payload['issue_id']}",
+        f"Issue path: {payload['issue_path']}",
+        f"Status: {payload['status']}",
+        f"Flow prepared until: {payload['flow_prepared_until']}",
+        f"Next step: {payload['next_step']}",
+    ]
+    if payload.get("log_timestamp"):
+        lines.append(f"Log timestamp: {payload['log_timestamp']}")
+    lines.append("Runbook:")
+    lines.append(f"- {payload['runbook_line']}")
+    return lines
+
+
+def _render_output(payload: dict[str, Any], output_format: str) -> str:
+    return render_output(payload, output_format, _render_md(payload), dry_run=bool(payload.get("dry_run")))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Run YODA Prep Flow for one issue",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Agent guidance:\n"
+            "- Purpose: prepare Study/Document for one issue without entering implementation.\n"
+            "- Use in YODA Framework: run this when the human explicitly enters YODA Prep Flow.\n"
+            "- Selection: requires --issue and ignores backlog order/dependencies for preparation only.\n"
+            "- Expected moment: call once per prep step, execute returned Study/Document instructions,\n"
+            "  then call again after explicit human authorization to continue.\n"
+            "- Result: after Document, the issue remains to-do with flow_prepared_until=document;\n"
+            "  YODA Flow later starts it directly in Implement."
+        ),
+    )
+    add_global_flags(parser)
+    parser.add_argument("--issue", required=False, help="Issue id (dev-####)")
+
+    args = parser.parse_args()
+    configure_logging(args.verbose)
+    output_format = resolve_format(args)
+
+    try:
+        dev = (args.dev or "").strip()
+        if not dev:
+            raise YodaError(
+                "--dev is required. Use the developer slug prefix from issue filenames <dev>-<NNNN>-<slug>.md.",
+                exit_code=ExitCode.VALIDATION,
+            )
+        validate_slug(dev)
+        issue_id = (args.issue or "").strip()
+        if not issue_id:
+            raise YodaError("--issue is required", exit_code=ExitCode.VALIDATION)
+        validate_issue_id(issue_id, dev)
+
+        issue_path, metadata = _load_issue(issue_id)
+        transition = _apply_prep_step(issue_path, metadata, bool(args.dry_run))
+        payload = {
+            "issue_id": issue_id,
+            "issue_path": _relative(issue_path),
+            "status": transition["status"],
+            "phase": transition["phase"],
+            "flow_prepared_until": transition["flow_prepared_until"],
+            "next_step": transition["next_step"],
+            "runbook_line": transition["runbook_line"],
+            "log_timestamp": transition["log_timestamp"],
+            "dry_run": bool(args.dry_run),
+        }
+        print(_render_output(payload, output_format))
+        return ExitCode.SUCCESS
+    except YodaError as exc:
+        logging.error(str(exc))
+        return exc.exit_code
+    except Exception as exc:  # pragma: no cover
+        logging.error("Unexpected error: %s", exc)
+        return ExitCode.ERROR
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/yoda/yoda.md
+++ b/yoda/yoda.md
@@ -11,7 +11,7 @@ Use script runbooks as the source of truth for operational details.
 
 ## Entry order
 
-1. Read `REPO_INTENT.md`.
+1. Read the YODA-local agent entry file when present (`yoda/AGENTS.md`, `yoda/GEMINI.md`, or `yoda/CLAUDE.md`).
 2. Read this file (`yoda/yoda.md`).
 3. Resolve developer slug from `--dev`; if missing, ask human and rerun with `--dev <slug>`.
 
@@ -22,6 +22,7 @@ Use script runbooks as the source of truth for operational details.
 
 ## Source of truth
 
+- Agent entry files: `yoda/AGENTS.md`, `yoda/GEMINI.md`, `yoda/CLAUDE.md`
 - Issues markdown: `yoda/project/issues/<id>-<slug>.md`
 - Dependencies: front matter `depends_on`
 - Flow execution log: section `## Flow log` inside each issue markdown, use `log_add.py --help`

--- a/yoda/yoda.md
+++ b/yoda/yoda.md
@@ -29,6 +29,7 @@ Use script runbooks as the source of truth for operational details.
 ## YODA modes
 
 - `YODA Flow`: execute one issue through phases.
+- `YODA Prep Flow`: prepare Study/Document for one issue without implementation.
 - `YODA Intake`: create/refine backlog issues.
 
 Do not mix modes implicitly. Enter and exit each mode explicitly.
@@ -72,6 +73,26 @@ External issue line rule:
 - Derive provider and number from `extern_issue_file` (for example, `../extern_issues/github-2.json` => `GitHub` and `#2`).
 - Omit the line when no external association exists.
 
+## YODA Prep Flow
+
+Use YODA Prep Flow only when the human explicitly wants to prepare an issue's
+Study/Document work without entering implementation.
+
+Before using it, read the script runbook:
+```bash
+python3 yoda/scripts/yoda_prep_flow.py --help
+```
+
+Entry:
+1. Confirm the human intent includes entering YODA Prep Flow.
+2. Run `python3 yoda/scripts/yoda_prep_flow.py --dev <slug> --issue <id>`.
+3. Follow the returned runbook for the selected prep step.
+
+Prep policy:
+- YODA Prep Flow works on the explicit `--issue`; it does not select by backlog order.
+- It is allowed to prepare documentation independent of dependencies, but it does not authorize implementation.
+- When prep reaches Document, the issue remains `to-do` and YODA Flow later starts it at Implement.
+
 ## YODA Intake
 
 Entry:
@@ -108,6 +129,7 @@ Intake policy:
 ## Script authority map
 
 - `yoda_flow_next.py`: deterministic next-step selection + flow transition/runbook.
+- `yoda_prep_flow.py`: explicit issue Study/Document preparation without implementation.
 - `todo_update.py`: manual status/phase/metadata corrections.
 - `log_add.py`: compact one-line issue log outside normal flow path.
 - `todo_next.py`: next selectable issue (inspection helper).


### PR DESCRIPTION
## Summary
- Move as instruções de entrada do YODA para arquivos autocontidos em `yoda/` e renomeia a spec de entrada de agentes para refletir a nova abordagem.
- Remove de `init.py` qualquer mutação de arquivos de agente/intent na raiz do projeto host e atualiza docs, specs e empacotamento para essa regra.
- Adiciona o novo `yoda_prep_flow.py`, ajusta o fluxo de seleção de issues e cobre o comportamento com testes.

## Testing
- `python3 -m pytest yoda/scripts/tests`
- Validações de fluxo e contrato de pacote passaram com a suíte completa